### PR TITLE
feat: freebook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # minibook-support
-Software for CHUWI MiniBook (8-inch) / MiniBook X (10-inch) running Linux
+Software for CHUWI MiniBook (8-inch) / MiniBook X (10-inch) / FreeBook N100 (14-inch) running Linux
 
-- Enable the tablet mode of the MiniBook / MiniBook X automatically when the MiniBook is folded.
+- Enable the tablet mode of the MiniBook / MiniBook X / FreeBook N100 automatically when the MiniBook is folded.
 - Calibrate the trackpointer of the MiniBook (8-inch).
 
 ## Requirements
 
-- CHUWI MiniBook / MiniBook X
+- CHUWI MiniBook / MiniBook X / FreeBook N100
 - Linux 6.9 or later
   - Needed for MiniBook X
 
@@ -27,6 +27,9 @@ For other Linux distributions, please install the equivalent packages.
 - MiniBook X (10-inch)
   - Ubuntu 24.04
     - Linux 6.10.6
+- FreeBook N100 (14-inch)
+  - Arch Linux
+    - Linux 6.13.7-arch1-1
 
 ## Installation
 

--- a/moused/src/moused.c
+++ b/moused/src/moused.c
@@ -166,12 +166,12 @@ int main(int argc, char *argv[]) {
     char device_model[256] = {0};
     get_device_model(device_model, sizeof(device_model));
     debug_printf("Device model: %s\n", device_model);
-    if (strstr(device_model, "MiniBook") == NULL) {
+    if (strstr(device_model, "MiniBook") == NULL && strstr(device_model, "FreeBook") == NULL) {
         fprintf(stderr, "This device is not supported\n");
         recovery_device();
         return (EXIT_FAILURE);
     }
-    if (strncmp(device_model, "MiniBook X", 10) == 0) {
+    if (strncmp(device_model, "MiniBook X", 10) == 0 || strncmp(device_model, "FreeBook", 8) == 0) {
         input = open(MINIBOOKX_INPUT_DEVICE, O_RDWR);
         is_enabled_calibration = 0;
     } else {


### PR DESCRIPTION
Based on issue #23 but added a check for i2c port number due to Arch detecting iio devices on i2c-13 & i2c-14 instead of  i2c-0 and i2c-1 under N100 FreeBook.